### PR TITLE
Create library.json for PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,23 @@
+{
+  "name": "LedControl",
+  "keywords": "led, matrix, segment, display, driver, maxim, max7219, max7221",
+  "description": "An Arduino library for the MAX7221 and MAX7219 LED display drivers. Supports LED matrix displays, 7-segment displays, ands multiple daisychained drivers.",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/wayoda/LedControl.git"
+  },
+  "version": "1.0.6",
+  "authors": [
+    {
+      "name": "Eberhard Fahle",
+      "email": "e.fahle@wayoda.org",
+      "url": "http://wayoda.github.io/LedControl",
+      "maintainer": true
+    }
+  ],
+  "include": "src",
+  "examples": "examples/*/*.ino",
+  "frameworks": "arduino",
+  "platforms": "*"
+}


### PR DESCRIPTION
I thought it would be useful to have this library available through the [PlatformIO Libraries Registry](http://platformio.org/lib) so I went ahead and added a `library.json` file for this purpose. If you want to merge it, the library can then be registered from the command line as follows: 

`platformio lib register https://github.com/wayoda/LedControl/blob/master/library.json`

See http://docs.platformio.org/en/latest/userguide/lib/cmd_register.html for details.
