### PR TITLE
setByte() function

### DIFF
--- a/src/LedControl.cpp
+++ b/src/LedControl.cpp
@@ -189,6 +189,18 @@ void LedControl::setChar(int addr, int digit, char value, boolean dp) {
     spiTransfer(addr, digit+1,v);
 }
 
+void LedControl::setByte(int addr, int digit, byte value, boolean dp) {
+	int offset;
+	byte index,v;
+
+	offset=addr*8;
+	v = value;
+	if(dp)
+		v|=B10000000;
+	status[offset+digit]=v;
+	spiTransfer(addr, digit+1,v);
+}
+
 void LedControl::spiTransfer(int addr, volatile byte opcode, volatile byte data) {
     //Create an array with the data to shift out
     int offset=addr*2;

--- a/src/LedControl.h
+++ b/src/LedControl.h
@@ -182,9 +182,23 @@ class LedControl {
          * dp	sets the decimal point.
          */
         void setChar(int addr, int digit, char value, boolean dp);
- 
+
         /*
          * Display a specified byte on a 7-Segment Display.
+         * Specify a byte in the format: B_______
+         * where the blanks are either 1's or 0's corresponding to the on-off state of each of the segments A-G.
+         *
+         * Diagram of the 7-segments:
+         * --A--
+         * |   |
+         * F   B
+         * |   |
+         * --G--
+         * |   |
+         * E   C
+         * |   |
+         * --D--
+         *
          * Params:
          * addr address of the display
          * digit  the position of the digit on the display (0..7)

--- a/src/LedControl.h
+++ b/src/LedControl.h
@@ -182,6 +182,16 @@ class LedControl {
          * dp	sets the decimal point.
          */
         void setChar(int addr, int digit, char value, boolean dp);
+ 
+        /*
+         * Display a specified byte on a 7-Segment Display.
+         * Params:
+         * addr address of the display
+         * digit  the position of the digit on the display (0..7)
+         * value the value to be displayed, with each bit corresponding to a segment A-G
+         * dp sets the decimal point.
+         */
+         void setByte(int addr, int digit, byte value, boolean dp);
 };
 
 #endif	//LedControl.h


### PR DESCRIPTION
Added a setByte() function for displaying an arbitrary shape on a 7-segment display by specifying the on-off states for each of the segments A-G. 

Example usage: B0111111 corresponds to an upside-down A
